### PR TITLE
Be explicit about what will happen.

### DIFF
--- a/launcher-src/uMain.pas
+++ b/launcher-src/uMain.pas
@@ -71,8 +71,8 @@ implementation
 
 uses uOptions;
 
-const LANG_RESUME_LAST_GAME = 'Continue last save game';
-      LANG_DO_NOT_RESUME_LAST_GAME = 'Do not continue last save game';
+const LANG_RESUME_LAST_GAME = 'Will not continue last save game';
+      LANG_DO_NOT_RESUME_LAST_GAME = 'Will continue last save game';
 
       LANG_DISABLE_STEAM_WORKSHOP = 'Disable Steam Workshop';
       LANG_ENABLE_STEAM_WORKSHOP = 'Enable Steam Workshop';


### PR DESCRIPTION
I'm confused by the current launcher.  When I see a button called "Continue last save game", I can think two things.  "The game will continue" or "When I click on the button the game will continue."  From experience, the **latter seems correct...  This is besides the point, focus on the confusion one experiences the first time they see this.

This is a simple fix and by no means the only wording that *could be unambiguous.  I believe that radio options would be better than a single button.

`*` There is likely somer localization going on here, in that different parts of the world may read any wording differently.  I'm north-central USA, AKA Minnesota.

`**` This is the opposite of what I'd expect, BTW.  Thus, adding the word `will` and reversing the meaning removes ambiguity for my local.  When I read "Will continue", I'm most likely to think that if I do nothing the game will continue.
I do see the issue that there is no explanation on what todo if that's not what I want to happen.  This is the smaller of the two bugs, IMHO.